### PR TITLE
Add support for decoding discounts and coupons

### DIFF
--- a/include/stripe.hrl
+++ b/include/stripe.hrl
@@ -12,6 +12,7 @@
 -type token_id()     :: binary(). % tok_*
 -type invoiceitem_id() :: binary(). % ii_*
 -type invoice_id()     :: binary(). % in_*
+-type name()         :: binary() | string().
 -type desc()         :: binary() | string().
 -type email()        :: binary() | string().
 -type json()         :: tuple().
@@ -55,7 +56,8 @@
 %%%--------------------------------------------------------------------
 %%% Records / Stripe Objects
 %%%--------------------------------------------------------------------
--record(stripe_card, {last4      :: binary(),
+-record(stripe_card, {name       :: name(),
+                      last4      :: binary(),
                       exp_year   :: 2011..3000,
                       exp_month  :: 1..12,
                       type       :: credit_provider(),
@@ -98,6 +100,8 @@
 -record(stripe_subscription, {status        :: atom(),
                               current_period_start :: epoch(),
                               current_period_end   :: epoch(),
+                              trial_start          :: epoch(),
+                              trial_end            :: epoch(),
                               ended_at             :: epoch(),
                               canceled_at          :: epoch(),
                               customer             :: customer_id(),

--- a/include/stripe.hrl
+++ b/include/stripe.hrl
@@ -7,6 +7,7 @@
 -type price()        :: 50..500000000.  % valid charge prices. $0.50 to $5M.
 -type currency()     :: usd.
 -type customer_id()  :: binary(). % cu_* | cus_*  (docs show both in use)
+-type coupon_id()    :: binary(). % user specidied coupon ID
 -type plan_id()      :: binary(). % user specified plan ID
 -type charge_id()    :: binary(). % ch_*
 -type token_id()     :: binary(). % tok_*
@@ -110,6 +111,23 @@
                               plan                 :: #stripe_plan{}
                              }).
 
+-record(stripe_coupon, {id                 :: coupon_id(),
+                        percent_off        :: amount(),
+                        amount_off         :: amount(),
+                        currentcy          :: currency(),
+                        duration           :: amount(),
+                        redeem_by          :: epoch(),
+                        max_redemptions    :: amount(),
+                        times_redeemed     :: amount(),
+                        duration_in_months :: amount()
+                       }).
+
+-record(stripe_discount, {coupon   :: #stripe_coupon{},
+                          start    :: epoch(),
+                          'end'    :: epoch(),
+                          customer :: customer_id()
+                         }).
+
 -record(stripe_customer, {id              :: customer_id(),
                           created         :: epoch(),
                           description     :: desc(),
@@ -118,7 +136,7 @@
                           email           :: email(),
                           delinquent      :: boolean(),
                           subscription    :: #stripe_subscription{},
-                          discount        :: amount(),
+                          discount        :: #stripe_discount{},
                           account_balance :: amount()
                          }).
 

--- a/src/stripe.erl
+++ b/src/stripe.erl
@@ -247,6 +247,8 @@ json_to_record(subscription, DecodedResult) when is_list(DecodedResult) ->
   #stripe_subscription{status               = binary_to_atom(?V(status), utf8),
                        current_period_start = ?V(current_period_start),
                        current_period_end   = ?V(current_period_end),
+                       trial_start          = ?V(trial_start),
+                       trial_end            = ?V(trial_end),
                        ended_at             = ?V(ended_at),
                        canceled_at          = ?V(canceled_at),
                        customer             = ?V(customer),
@@ -269,7 +271,8 @@ json_to_record(Type, DecodedResult) ->
 proplist_to_card(null) -> null;
 proplist_to_card(Card) ->
   DecodedResult = Card,
-  #stripe_card{last4               = ?V(last4),
+  #stripe_card{name                = ?V(name),
+               last4               = ?V(last4),
                exp_month           = ?V(exp_month),
                exp_year            = ?V(exp_year),
                type                = ?V(type),

--- a/src/stripe.erl
+++ b/src/stripe.erl
@@ -239,8 +239,29 @@ json_to_record(customer, DecodedResult) ->
                    email           = ?V(email),
                    delinquent      = ?V(delinquent),
                    subscription    = json_to_record(subscription, ?V(subscription)),
-                   discount        = ?V(discount),
+                   discount        = json_to_record(discount, ?V(discount)),
                    account_balance = ?V(account_balance)};
+
+json_to_record(discount, null) -> null;
+json_to_record(discount, DecodedResult) ->
+  #stripe_discount{coupon   = json_to_record(coupon, ?V(coupon)),
+                   start    = ?V(start),
+                   'end'    = ?V('end'),
+                   customer = ?V(customer)
+                  };
+
+json_to_record(coupon, null) -> null;
+json_to_record(coupon, DecodedResult) ->
+  #stripe_coupon{id                 = ?V(id),
+                 percent_off        = ?V(percent_off),
+                 amount_off         = ?V(amount_off),
+                 currentcy          = binary_to_atom(?V(currency), utf8),
+                 duration           = ?V(duration),
+                 redeem_by          = ?V(redeem_by),
+                 max_redemptions    = ?V(max_redemptions),
+                 times_redeemed     = ?V(times_redeemed),
+                 duration_in_months = ?V(duration_in_months)
+                };
 
 json_to_record(subscription, null) -> null;
 json_to_record(subscription, DecodedResult) when is_list(DecodedResult) ->
@@ -266,6 +287,7 @@ json_to_record(invoiceitem, DecodedResult) ->
                       proration    = ?V(proration)};
 
 json_to_record(Type, DecodedResult) ->
+  error_logger:add_report_handler({unimplemented, ?MODULE, json_to_record, Type, DecodedResult}),
   {not_implemented_yet, Type, DecodedResult}.
 
 proplist_to_card(null) -> null;


### PR DESCRIPTION
The code was assuming that discounts were amount(), but they are objects and they can contain a coupon. This change adds #stripe_discount{} and #stripe_coupon{}.
