### PR TITLE
Fix eunit tests and transfer_create function

### DIFF
--- a/include/stripe.hrl
+++ b/include/stripe.hrl
@@ -331,4 +331,4 @@
                           account        :: #stripe_bank_account{},
                           description    :: desc(),
                           recipient      :: recipient_id(),
-                          statement_description :: desc()}).
+                          statement_descriptor :: desc()}).

--- a/src/stripe.erl
+++ b/src/stripe.erl
@@ -374,7 +374,7 @@ json_to_record(transfer, DecodedResult) ->
                    account      = proplist_to_bank_account(?V(account)),
                    description  = ?V(description),
                    recipient    = ?V(recipient),
-                   statement_description = ?V(statement_description)};
+                   statement_descriptor = ?V(statement_descriptor)};
 
 json_to_record(Type, DecodedResult) ->
   error_logger:error_msg({unimplemented, ?MODULE, json_to_record, Type, DecodedResult}),

--- a/src/stripe.erl
+++ b/src/stripe.erl
@@ -135,7 +135,7 @@ transfer_create(Amount, Currency, RecipientId, Desc, StatementDesc) ->
             {currency, Currency},
             {recipient, RecipientId},
             {description, Desc},
-            {statement_description, StatementDesc}],
+            {statement_descriptor, StatementDesc}],
   request_transfer_create(Fields).
 
 transfer_cancel(TransferId) ->


### PR DESCRIPTION
Several unit tests were failing when I attempted to use the
library.  These failures came down to really two errors:
1. [The Stripe API documentation for create transfer](https://stripe.com/docs/api/curl#create_transfer)
   has a field for `statement_descriptor` rather than `statement_description`
2. If no card cvc check is sent, the API will return
   "unchecked" rather than "Not Returned by API"
